### PR TITLE
chore(ledger): Improve pre-existing database handling

### DIFF
--- a/ledger/db/query.sql.go
+++ b/ledger/db/query.sql.go
@@ -46,8 +46,36 @@ func (q *Queries) CreateBank(ctx context.Context, arg CreateBankParams) (Bank, e
 	return i, err
 }
 
+const createBankIfNotExists = `-- name: CreateBankIfNotExists :exec
+INSERT OR IGNORE INTO banks (
+  bid, code, name, country_id, currency_id
+) VALUES (
+  ?, ?, ?, ?, ?
+)
+`
+
+type CreateBankIfNotExistsParams struct {
+	Bid        string
+	Code       string
+	Name       string
+	CountryID  int64
+	CurrencyID int64
+}
+
+// Used to preseed
+func (q *Queries) CreateBankIfNotExists(ctx context.Context, arg CreateBankIfNotExistsParams) error {
+	_, err := q.db.ExecContext(ctx, createBankIfNotExists,
+		arg.Bid,
+		arg.Code,
+		arg.Name,
+		arg.CountryID,
+		arg.CurrencyID,
+	)
+	return err
+}
+
 const createCountry = `-- name: CreateCountry :exec
-INSERT INTO countries (
+INSERT OR IGNORE INTO countries (
   code, name
 ) VALUES (
   ?, ?
@@ -65,7 +93,7 @@ func (q *Queries) CreateCountry(ctx context.Context, arg CreateCountryParams) er
 }
 
 const createCurrency = `-- name: CreateCurrency :exec
-INSERT INTO currencies (
+INSERT OR IGNORE INTO currencies (
   code, name, minor_unit
 ) VALUES (
   ?, ?, ?

--- a/ledger/internal/fixtures/fixtures.go
+++ b/ledger/internal/fixtures/fixtures.go
@@ -180,7 +180,7 @@ func preseedBanks(ctx context.Context, query *db.Queries) error {
 			return fmt.Errorf("could not find currency (%q) for fixture (%q): %w", currencyCode, name, err)
 		}
 
-		_, err = query.CreateBank(ctx, db.CreateBankParams{
+		err = query.CreateBankIfNotExists(ctx, db.CreateBankIfNotExistsParams{
 			Bid:        bid,
 			Code:       code,
 			Name:       name,

--- a/ledger/sql/query.sql
+++ b/ledger/sql/query.sql
@@ -28,6 +28,14 @@ INSERT INTO banks (
 )
 RETURNING *;
 
+-- Used to preseed
+-- name: CreateBankIfNotExists :exec
+INSERT OR IGNORE INTO banks (
+  bid, code, name, country_id, currency_id
+) VALUES (
+  ?, ?, ?, ?, ?
+);
+
 -- name: DeleteBankByCode :exec
 DELETE FROM banks WHERE code = ?;
 
@@ -44,7 +52,7 @@ SELECT * FROM countries
 WHERE id = ? LIMIT 1;
 
 -- name: CreateCountry :exec
-INSERT INTO countries (
+INSERT OR IGNORE INTO countries (
   code, name
 ) VALUES (
   ?, ?
@@ -63,7 +71,7 @@ SELECT * FROM currencies
 WHERE id = ? LIMIT 1;
 
 -- name: CreateCurrency :exec
-INSERT INTO currencies (
+INSERT OR IGNORE INTO currencies (
   code, name, minor_unit
 ) VALUES (
   ?, ?, ?

--- a/ledger/sql/schema.sql
+++ b/ledger/sql/schema.sql
@@ -1,6 +1,6 @@
 -- For SQLite datatypes, see: https://www.sqlite.org/datatype3.html
 
-CREATE TABLE banks (
+CREATE TABLE IF NOT EXISTS banks (
   id INTEGER PRIMARY KEY,
   -- public bank id, something like `bk_1a2B3c4`
   bid text NOT NULL,
@@ -13,7 +13,7 @@ CREATE TABLE banks (
   FOREIGN KEY(currency_id) REFERENCES currencies(id)
 );
 
-CREATE TABLE countries (
+CREATE TABLE IF NOT EXISTS countries (
   id INTEGER PRIMARY KEY,
   -- ISO 3166 Alpha-3 code
   code text NOT NULL,
@@ -21,7 +21,7 @@ CREATE TABLE countries (
   UNIQUE(code)
 );
 
-CREATE TABLE currencies (
+CREATE TABLE IF NOT EXISTS currencies (
   id INTEGER PRIMARY KEY,
   -- ISO 4217 Alphabetic code
   code text NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE currencies (
   UNIQUE(code)
 );
 
-CREATE TABLE transactions (
+CREATE TABLE IF NOT EXISTS transactions (
   id INTEGER PRIMARY KEY,
   -- public transaction id, something like `txn_9J8i7H6`
   tid text NOT NULL,


### PR DESCRIPTION
Since we're not using `:memory:` in the actual deployed version, we need to account for tables and pre-seed entries existing, this adds the appropriate handling for that.