### PR TITLE
feat/full backend impl

### DIFF
--- a/hack/scale.sh
+++ b/hack/scale.sh
@@ -8,7 +8,7 @@ fi
 
 for i in {1..10000}
 do
-  wash start component ./nordhaven-validator/build/nordhaven-validator.composed_s.wasm v$i --host-id $HOST_ID --skip-wait
+  wash start component ./nordhaven-validator/build/nordhaven-validator.composed.wasm v$i --host-id $HOST_ID --skip-wait
   wash config put v$i-host host=v$i
   wash link put http v$i --link-name v$i --interfaces incoming-handler wasi http --source-config v$i-host
 done

--- a/icamer-validator/main.go
+++ b/icamer-validator/main.go
@@ -20,9 +20,9 @@ func Validate(t validation.Transaction) validation.ValidateResponse {
 		}
 	}
 
-	if (t.Origin.Country == "USA" && t.Destination.Country == "UK") ||
-		(t.Origin.Country == "UK" && t.Destination.Country == "USA") ||
-		(t.Origin.Country == "UK" && t.Destination.Country == "UK") ||
+	if (t.Origin.Country == "USA" && t.Destination.Country == "GBR") ||
+		(t.Origin.Country == "GBR" && t.Destination.Country == "USA") ||
+		(t.Origin.Country == "GBR" && t.Destination.Country == "GBR") ||
 		(t.Origin.Country == "USA" && t.Destination.Country == "USA") {
 		return validation.ValidateResponse{
 			Approved: true,
@@ -32,7 +32,7 @@ func Validate(t validation.Transaction) validation.ValidateResponse {
 
 	return validation.ValidateResponse{
 		Approved: false,
-		Reason:   cm.Some("Transaction did not occur in the USA or UK"),
+		Reason:   cm.Some("Transaction did not occur in the USA or GBR"),
 	}
 }
 

--- a/ledger/api/ledger/v1/transaction.proto
+++ b/ledger/api/ledger/v1/transaction.proto
@@ -8,10 +8,6 @@ message Transaction {
   string destination = 3;
   uint64 amount = 4;
   string currency = 5;
-  TransactionStatus status = 6;
-}
-
-message TransactionStatus {
-  string status = 1;
-  string reason = 2;
+  string status = 6;
+  string reason = 7;
 }

--- a/ledger/api/ledger/v1/transaction_service.proto
+++ b/ledger/api/ledger/v1/transaction_service.proto
@@ -14,7 +14,8 @@ message StoreTransactionRequest {
   string destination = 2;
   uint64 amount = 3;
   string currency = 4;
-  TransactionStatus status = 5;
+  string status = 5;
+  string reason = 6;
 }
 
 message StoreTransactionResponse {

--- a/ledger/internal/api/ledgerv1/transaction.pb.go
+++ b/ledger/internal/api/ledgerv1/transaction.pb.go
@@ -28,7 +28,8 @@ type Transaction struct {
 	Destination   string                 `protobuf:"bytes,3,opt,name=destination,proto3" json:"destination,omitempty"`
 	Amount        uint64                 `protobuf:"varint,4,opt,name=amount,proto3" json:"amount,omitempty"`
 	Currency      string                 `protobuf:"bytes,5,opt,name=currency,proto3" json:"currency,omitempty"`
-	Status        *TransactionStatus     `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	Status        string                 `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	Reason        string                 `protobuf:"bytes,7,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -98,59 +99,14 @@ func (x *Transaction) GetCurrency() string {
 	return ""
 }
 
-func (x *Transaction) GetStatus() *TransactionStatus {
-	if x != nil {
-		return x.Status
-	}
-	return nil
-}
-
-type TransactionStatus struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
-	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *TransactionStatus) Reset() {
-	*x = TransactionStatus{}
-	mi := &file_api_ledger_v1_transaction_proto_msgTypes[1]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TransactionStatus) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TransactionStatus) ProtoMessage() {}
-
-func (x *TransactionStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_api_ledger_v1_transaction_proto_msgTypes[1]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TransactionStatus.ProtoReflect.Descriptor instead.
-func (*TransactionStatus) Descriptor() ([]byte, []int) {
-	return file_api_ledger_v1_transaction_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *TransactionStatus) GetStatus() string {
+func (x *Transaction) GetStatus() string {
 	if x != nil {
 		return x.Status
 	}
 	return ""
 }
 
-func (x *TransactionStatus) GetReason() string {
+func (x *Transaction) GetReason() string {
 	if x != nil {
 		return x.Reason
 	}
@@ -161,17 +117,15 @@ var File_api_ledger_v1_transaction_proto protoreflect.FileDescriptor
 
 const file_api_ledger_v1_transaction_proto_rawDesc = "" +
 	"\n" +
-	"\x1fapi/ledger/v1/transaction.proto\x12\rapi.ledger.v1\"\xc5\x01\n" +
+	"\x1fapi/ledger/v1/transaction.proto\x12\rapi.ledger.v1\"\xbb\x01\n" +
 	"\vTransaction\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06origin\x18\x02 \x01(\tR\x06origin\x12 \n" +
 	"\vdestination\x18\x03 \x01(\tR\vdestination\x12\x16\n" +
 	"\x06amount\x18\x04 \x01(\x04R\x06amount\x12\x1a\n" +
-	"\bcurrency\x18\x05 \x01(\tR\bcurrency\x128\n" +
-	"\x06status\x18\x06 \x01(\v2 .api.ledger.v1.TransactionStatusR\x06status\"C\n" +
-	"\x11TransactionStatus\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status\x12\x16\n" +
-	"\x06reason\x18\x02 \x01(\tR\x06reasonB\xba\x01\n" +
+	"\bcurrency\x18\x05 \x01(\tR\bcurrency\x12\x16\n" +
+	"\x06status\x18\x06 \x01(\tR\x06status\x12\x16\n" +
+	"\x06reason\x18\a \x01(\tR\x06reasonB\xba\x01\n" +
 	"\x11com.api.ledger.v1B\x10TransactionProtoP\x01Z=github.com/cosmonic-labs/wasmpay/ledger/internal/api/ledgerv1\xa2\x02\x03ALX\xaa\x02\rApi.Ledger.V1\xca\x02\rApi\\Ledger\\V1\xe2\x02\x19Api\\Ledger\\V1\\GPBMetadata\xea\x02\x0fApi::Ledger::V1b\x06proto3"
 
 var (
@@ -186,18 +140,16 @@ func file_api_ledger_v1_transaction_proto_rawDescGZIP() []byte {
 	return file_api_ledger_v1_transaction_proto_rawDescData
 }
 
-var file_api_ledger_v1_transaction_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_api_ledger_v1_transaction_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_api_ledger_v1_transaction_proto_goTypes = []any{
-	(*Transaction)(nil),       // 0: api.ledger.v1.Transaction
-	(*TransactionStatus)(nil), // 1: api.ledger.v1.TransactionStatus
+	(*Transaction)(nil), // 0: api.ledger.v1.Transaction
 }
 var file_api_ledger_v1_transaction_proto_depIdxs = []int32{
-	1, // 0: api.ledger.v1.Transaction.status:type_name -> api.ledger.v1.TransactionStatus
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	0, // [0:0] is the sub-list for method output_type
+	0, // [0:0] is the sub-list for method input_type
+	0, // [0:0] is the sub-list for extension type_name
+	0, // [0:0] is the sub-list for extension extendee
+	0, // [0:0] is the sub-list for field type_name
 }
 
 func init() { file_api_ledger_v1_transaction_proto_init() }
@@ -211,7 +163,7 @@ func file_api_ledger_v1_transaction_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_ledger_v1_transaction_proto_rawDesc), len(file_api_ledger_v1_transaction_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/ledger/internal/api/ledgerv1/transaction_service.pb.go
+++ b/ledger/internal/api/ledgerv1/transaction_service.pb.go
@@ -27,7 +27,8 @@ type StoreTransactionRequest struct {
 	Destination   string                 `protobuf:"bytes,2,opt,name=destination,proto3" json:"destination,omitempty"`
 	Amount        uint64                 `protobuf:"varint,3,opt,name=amount,proto3" json:"amount,omitempty"`
 	Currency      string                 `protobuf:"bytes,4,opt,name=currency,proto3" json:"currency,omitempty"`
-	Status        *TransactionStatus     `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	Status        string                 `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	Reason        string                 `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -90,11 +91,18 @@ func (x *StoreTransactionRequest) GetCurrency() string {
 	return ""
 }
 
-func (x *StoreTransactionRequest) GetStatus() *TransactionStatus {
+func (x *StoreTransactionRequest) GetStatus() string {
 	if x != nil {
 		return x.Status
 	}
-	return nil
+	return ""
+}
+
+func (x *StoreTransactionRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
 }
 
 type StoreTransactionResponse struct {
@@ -225,13 +233,14 @@ var File_api_ledger_v1_transaction_service_proto protoreflect.FileDescriptor
 
 const file_api_ledger_v1_transaction_service_proto_rawDesc = "" +
 	"\n" +
-	"'api/ledger/v1/transaction_service.proto\x12\rapi.ledger.v1\x1a\x1fapi/ledger/v1/transaction.proto\"\xc1\x01\n" +
+	"'api/ledger/v1/transaction_service.proto\x12\rapi.ledger.v1\x1a\x1fapi/ledger/v1/transaction.proto\"\xb7\x01\n" +
 	"\x17StoreTransactionRequest\x12\x16\n" +
 	"\x06origin\x18\x01 \x01(\tR\x06origin\x12 \n" +
 	"\vdestination\x18\x02 \x01(\tR\vdestination\x12\x16\n" +
 	"\x06amount\x18\x03 \x01(\x04R\x06amount\x12\x1a\n" +
-	"\bcurrency\x18\x04 \x01(\tR\bcurrency\x128\n" +
-	"\x06status\x18\x05 \x01(\v2 .api.ledger.v1.TransactionStatusR\x06status\"*\n" +
+	"\bcurrency\x18\x04 \x01(\tR\bcurrency\x12\x16\n" +
+	"\x06status\x18\x05 \x01(\tR\x06status\x12\x16\n" +
+	"\x06reason\x18\x06 \x01(\tR\x06reason\"*\n" +
 	"\x18StoreTransactionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"\x19\n" +
 	"\x17ListTransactionsRequest\"Z\n" +
@@ -260,21 +269,19 @@ var file_api_ledger_v1_transaction_service_proto_goTypes = []any{
 	(*StoreTransactionResponse)(nil), // 1: api.ledger.v1.StoreTransactionResponse
 	(*ListTransactionsRequest)(nil),  // 2: api.ledger.v1.ListTransactionsRequest
 	(*ListTransactionsResponse)(nil), // 3: api.ledger.v1.ListTransactionsResponse
-	(*TransactionStatus)(nil),        // 4: api.ledger.v1.TransactionStatus
-	(*Transaction)(nil),              // 5: api.ledger.v1.Transaction
+	(*Transaction)(nil),              // 4: api.ledger.v1.Transaction
 }
 var file_api_ledger_v1_transaction_service_proto_depIdxs = []int32{
-	4, // 0: api.ledger.v1.StoreTransactionRequest.status:type_name -> api.ledger.v1.TransactionStatus
-	5, // 1: api.ledger.v1.ListTransactionsResponse.transactions:type_name -> api.ledger.v1.Transaction
-	0, // 2: api.ledger.v1.TransactionService.StoreTransaction:input_type -> api.ledger.v1.StoreTransactionRequest
-	2, // 3: api.ledger.v1.TransactionService.ListTransactions:input_type -> api.ledger.v1.ListTransactionsRequest
-	1, // 4: api.ledger.v1.TransactionService.StoreTransaction:output_type -> api.ledger.v1.StoreTransactionResponse
-	3, // 5: api.ledger.v1.TransactionService.ListTransactions:output_type -> api.ledger.v1.ListTransactionsResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	4, // 0: api.ledger.v1.ListTransactionsResponse.transactions:type_name -> api.ledger.v1.Transaction
+	0, // 1: api.ledger.v1.TransactionService.StoreTransaction:input_type -> api.ledger.v1.StoreTransactionRequest
+	2, // 2: api.ledger.v1.TransactionService.ListTransactions:input_type -> api.ledger.v1.ListTransactionsRequest
+	1, // 3: api.ledger.v1.TransactionService.StoreTransaction:output_type -> api.ledger.v1.StoreTransactionResponse
+	3, // 4: api.ledger.v1.TransactionService.ListTransactions:output_type -> api.ledger.v1.ListTransactionsResponse
+	3, // [3:5] is the sub-list for method output_type
+	1, // [1:3] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_api_ledger_v1_transaction_service_proto_init() }

--- a/ledger/server/transaction.go
+++ b/ledger/server/transaction.go
@@ -62,8 +62,8 @@ func (srv *TransactionServer) StoreTransaction(ctx context.Context, req *connect
 		DestinationID: destination.Bank.ID,
 		CurrencyID:    currency.ID,
 		Amount:        int64(req.Msg.GetAmount()),
-		Status:        req.Msg.Status.GetStatus(),
-		Reason:        req.Msg.Status.GetReason(),
+		Status:        req.Msg.GetStatus(),
+		Reason:        req.Msg.GetReason(),
 	})
 	if err != nil {
 		logger.Error("could not store transaction", "error", err)
@@ -94,10 +94,8 @@ func (srv *TransactionServer) ListTransactions(ctx context.Context, req *connect
 			Destination: result.Bank_2.Code,
 			Amount:      uint64(result.Transaction.Amount),
 			Currency:    result.Currency.Code,
-			Status: &ledgerv1.TransactionStatus{
-				Status: result.Transaction.Status,
-				Reason: result.Transaction.Reason,
-			},
+			Status:      result.Transaction.Status,
+			Reason:      result.Transaction.Reason,
 		})
 	}
 

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -15,6 +15,7 @@ interface types {
       amount: s64,
       currency: string,
       status: string,
+      reason: string,
    }
    record validate-response {
       approved: bool,


### PR DESCRIPTION
- **chore: use unsigned for scale**
- **feat: support all backend ops in api_gateway**

This PR implements the remaining operations all the way through the ledger backend.

I only had to change one thing with the ledger service, un-nesting the status and reason for the transaction, since it didn't deserialize properly in tinygo.

All successful responses return a 200 response with structure `{"data": {}}` with the internal data, and all error responses return either a 400/404/500 with `{"code": "", "message": ""}`
