### PR TITLE
feat: support showing failed error, reload transactions 

### DIFF
--- a/ts-packages/common/src/hooks/useTransactions.ts
+++ b/ts-packages/common/src/hooks/useTransactions.ts
@@ -6,6 +6,7 @@ import {useApi} from '#services/backend/hooks/useApi.ts';
 export function useTransactions() {
   const [isLoading, setIsLoading] = React.useState(true);
   const [transactions, setTransactions] = React.useState<Transaction[]>([]);
+  const [reloadFlag, setReloadFlag] = React.useState(false);
   const api = useApi();
 
   const fetchTransactions = React.useCallback(async () => {
@@ -18,6 +19,10 @@ export function useTransactions() {
 
   React.useEffect(() => {
     fetchTransactions();
+  }, [reloadFlag]);
+
+  const reloadTransactions = React.useCallback(() => {
+    setReloadFlag((prev) => !prev);
   }, []);
 
   const balance = React.useMemo(
@@ -27,15 +32,24 @@ export function useTransactions() {
   );
 
   const createTransaction = React.useCallback(
-    async (origin: Bank | undefined, destination: Bank | undefined, pro: boolean) => {
+    async (
+      origin: Bank | undefined,
+      destination: Bank | undefined,
+      amount: number,
+      pro: boolean,
+    ) => {
       if (!origin || !destination) {
         console.error('Bank not found');
+        return;
+      }
+      if (amount <= 0) {
+        console.error('Amount cannot be zero');
         return;
       }
 
       const transaction: CreateTransaction = {
         currency: origin.currency,
-        amount: 100,
+        amount,
         origin,
         destination,
         status: 'Pending',
@@ -65,5 +79,5 @@ export function useTransactions() {
     [],
   );
 
-  return {transactions, balance, isLoading, createTransaction};
+  return {transactions, balance, isLoading, createTransaction, reloadTransactions};
 }

--- a/wasmpay-ui/src/features/dashboard/components/account-balance.tsx
+++ b/wasmpay-ui/src/features/dashboard/components/account-balance.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react';
 import Chart from 'react-apexcharts';
 import {ArrowDownIcon, ArrowUpIcon} from 'lucide-react';
-import {useTransactions} from '@repo/common/hooks/useTransactions';
 import {Transaction} from '@repo/common/types';
 import {DashboardCard} from '@/features/dashboard/components/dashboard-card';
 
-export function AccountBalance(): React.ReactElement {
-  const {transactions, balance, isLoading} = useTransactions();
+export function AccountBalance({
+  transactions,
+  balance,
+  isLoading,
+}: {
+  transactions: Transaction[];
+  balance: number;
+  isLoading: boolean;
+}): React.ReactElement {
   let chartBalance = 0;
   const chartData = transactions.map((t, i) => {
     if (t.status !== 'Cancelled') {

--- a/wasmpay-ui/src/features/dashboard/components/dashboard.tsx
+++ b/wasmpay-ui/src/features/dashboard/components/dashboard.tsx
@@ -3,19 +3,22 @@ import {AccountBalance} from './account-balance';
 import {Transactions} from '@/features/transactions/components/transactions';
 import {Chat} from '@/features/chat/components/chat';
 import {TransactionModal} from '@/features/transactions/components/transaction-modal';
+import {useTransactions} from '@repo/common/hooks/useTransactions';
 
 function Dashboard(): React.ReactElement {
+  const {transactions, balance, isLoading, reloadTransactions} = useTransactions();
+
   return (
     <div className="grid grid-cols-12 gap-3">
       <div className="col-span-12 md:col-span-6">
         <Chat />
       </div>
       <div className="col-span-12 md:col-span-6">
-        <AccountBalance />
+        <AccountBalance transactions={transactions} balance={balance} isLoading={isLoading} />
       </div>
       <div className="col-span-12">
-        <Transactions />
-        <TransactionModal />
+        <Transactions transactions={transactions} isLoading={isLoading} />
+        <TransactionModal reloadTransactions={reloadTransactions} />
       </div>
     </div>
   );

--- a/wasmpay-ui/src/features/transactions/components/transaction-modal.tsx
+++ b/wasmpay-ui/src/features/transactions/components/transaction-modal.tsx
@@ -23,7 +23,7 @@ import React from 'react';
 import {Loader2Icon} from 'lucide-react';
 import {toast} from 'sonner';
 
-export function TransactionModal() {
+export function TransactionModal({reloadTransactions}: {reloadTransactions: () => void}) {
   const {banks} = useBanks();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -43,20 +43,21 @@ export function TransactionModal() {
     setIsSubmitting(true);
     setError(null);
     toast.loading('Processing transaction...');
-    createTransaction(origin, destination, false)
+    console.dir(form);
+    createTransaction(origin, destination, form.amount || 0, false)
       .then(() => {
         setIsSubmitting(false);
+        reloadTransactions();
+        toast.dismiss();
+        toast.success('Transaction completed successfully!');
+        closeForm();
       })
       .catch((error) => {
         setIsSubmitting(false);
         toast.error('Transaction failed. Please try again.');
-        setError(error.message);
+        setError(error.response.message);
+        console.dir(error);
         console.error('Transaction failed:', error);
-      })
-      .finally(() => {
-        toast.dismiss();
-        toast.success('Transaction completed successfully!');
-        closeForm();
       });
   };
 
@@ -113,7 +114,7 @@ export function TransactionModal() {
             <Input
               id="request-amount"
               value={form.amount}
-              onChange={(e) => updateForm('amount', e.target.value)}
+              onChange={(e) => updateForm('amount', parseFloat(e.target.value))}
               placeholder="Enter amount"
               type="number"
               min="0.01"

--- a/wasmpay-ui/src/features/transactions/components/transactions.tsx
+++ b/wasmpay-ui/src/features/transactions/components/transactions.tsx
@@ -5,12 +5,16 @@ import {ArrowUpRight, ArrowDownLeft} from 'lucide-react';
 import {EmptyTransactionState} from './empty-state';
 import {Button} from '@/components/ui/button';
 import {Transaction} from '@repo/common/types';
-import {useTransactions} from '@repo/common/hooks/useTransactions';
 import {Loader} from '@/components/ui/loader';
 import {useTransactionForm} from '@/features/transactions/context/use-transaction-form';
 
-export function Transactions() {
-  const {transactions, isLoading} = useTransactions();
+export function Transactions({
+  transactions,
+  isLoading,
+}: {
+  transactions: Transaction[];
+  isLoading: boolean;
+}) {
   const {openForm} = useTransactionForm();
 
   return (

--- a/wasmpay-ui/src/features/transactions/context/transaction-form-context.tsx
+++ b/wasmpay-ui/src/features/transactions/context/transaction-form-context.tsx
@@ -1,3 +1,4 @@
+import {useBanks} from '@repo/common/hooks/useBanks';
 import * as React from 'react';
 
 type TransactionFormContextType = {
@@ -26,11 +27,12 @@ export const TransactionFormContext = React.createContext<TransactionFormContext
   closeForm: () => undefined,
 });
 
-const USER_BANK_ID = 'bk_s5MuMcA';
+const USER_BANK_CODE = 'nordhaven';
 
 export function TransactionFormProvider({children}: {children: React.ReactNode}) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [mode, setMode] = React.useState<'send' | 'request'>('send');
+  const {banks} = useBanks();
 
   const [form, setForm] = React.useState({
     origin: '',
@@ -39,11 +41,12 @@ export function TransactionFormProvider({children}: {children: React.ReactNode})
     currency: '',
   });
 
+  const userBank = banks.find((b) => b.code === USER_BANK_CODE);
   const openForm = (mode: 'send' | 'request') => {
     if (mode === 'send') {
-      setForm((prev) => ({...prev, origin: USER_BANK_ID}));
+      setForm((prev) => ({...prev, origin: userBank?.id || ''}));
     } else {
-      setForm((prev) => ({...prev, destination: USER_BANK_ID}));
+      setForm((prev) => ({...prev, destination: userBank?.id || ''}));
     }
     setMode(mode);
     setIsOpen(true);


### PR DESCRIPTION
This PR tweaks a few things to ensure that
1. Transactions that succeed result in an immediate transaction reload
2. Transactions that fail surface in the modal